### PR TITLE
Potential fix for code scanning alert no. 1: Client-side cross-site scripting

### DIFF
--- a/static/scripts/index.js
+++ b/static/scripts/index.js
@@ -113,7 +113,7 @@ function view() {
     let name = decodeURIComponent(
         location.hash.substring(1, location.hash.length)
     )
-    view.querySelector('h2').innerHTML = `# ${name}`
+    view.querySelector('h2').textContent = `# ${name}`
     for (const i of items) {
         let match = i.match(memeRegex);
         if (match[2] === name) {


### PR DESCRIPTION
Potential fix for [https://github.com/NekoCraftNetwork/memebox/security/code-scanning/1](https://github.com/NekoCraftNetwork/memebox/security/code-scanning/1)

To fix this DOM-based XSS vulnerability, we must ensure that user-controlled data is not inserted into the DOM as HTML. The best way is to use `textContent` instead of `innerHTML` when inserting untrusted data, as `textContent` treats the value as plain text and not as HTML, thus preventing script execution. In this case, on line 116, replace the use of `innerHTML` with `textContent` for the `h2` element. This change preserves the display of the hash value but prevents any HTML or script injection.

No new imports or dependencies are needed. Only the assignment to `innerHTML` on line 116 in `static/scripts/index.js` needs to be changed to use `textContent` and to include the `# ` prefix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
